### PR TITLE
[ISSUE-2] Flush the cache for PSRAM tests to get more accurate timing…

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -5,4 +5,4 @@ file(GLOB SOURCES *.c *.cpp *.S)
 
 idf_component_register(SRCS ${SOURCES}
                        INCLUDE_DIRS ""
-                       REQUIRES esp-dsp)
+                       REQUIRES esp-dsp esp_mm)


### PR DESCRIPTION
Added cache flushing/invalidation as suggested in #2 
Built/tested with IDF v5.3 as v5.1 doesn't seem to have esp_cache_msync(...) fully implemented.